### PR TITLE
Update hebcal.js

### DIFF
--- a/src/hebcal.js
+++ b/src/hebcal.js
@@ -627,7 +627,11 @@ HDateProto.omer = function() {
 };
 
 HDateProto.dafyomi = function(o) {
-	return dafyomi.dafname(dafyomi.dafyomi(this.greg()), o);
+	if (option === "n") {
+		return dafyomi.dafnumber(dafyomi.dafyomi(this.greg()), o)
+	} else {
+		return dafyomi.dafname(dafyomi.dafyomi(this.greg()), o);
+	}
 };
 
 HDateProto.tachanun = (function() {


### PR DESCRIPTION
HDate.dafyomi('h', "n") will return just the daf without the masechta